### PR TITLE
fix: Append traling slash to API endpoints

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithApi.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithApi.kt
@@ -68,9 +68,9 @@ sealed class FlagsmithApi : FuelRouting {
 
     override val path: String
         get() = when (this) {
-            is GetIdentityFlagsAndTraits -> "/identities"
-            is GetFlags -> "/flags"
-            is SetTrait -> "/traits"
-            is PostAnalytics -> "/analytics/flags"
+            is GetIdentityFlagsAndTraits -> "/identities/"
+            is GetFlags -> "/flags/"
+            is SetTrait -> "/traits/"
+            is PostAnalytics -> "/analytics/flags/"
         }
 }

--- a/FlagsmithClient/src/test/java/com/flagsmith/mockResponses/MockResponses.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/mockResponses/MockResponses.kt
@@ -6,9 +6,9 @@ import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.MediaType
 
 enum class MockEndpoint(val path: String, val body: String) {
-    GET_IDENTITIES("/identities", MockResponses.getIdentities),
-    GET_FLAGS("/flags", MockResponses.getFlags),
-    SET_TRAIT("/traits", MockResponses.setTrait)
+    GET_IDENTITIES("/identities/", MockResponses.getIdentities),
+    GET_FLAGS("/flags/", MockResponses.getFlags),
+    SET_TRAIT("/traits/", MockResponses.setTrait)
 }
 
 fun ClientAndServer.mockResponseFor(endpoint: MockEndpoint) {


### PR DESCRIPTION
Flagsmith self-hosted (https://github.com/Flagsmith/self-hosted) doesn't support calling api without trailing slash (the cloud version does). Android SDK is calling API without tailing slash. So we cannot use Android SDK with self-hosted Flagsmith server.

This PR add trailing slash to API endpoints in Android SDK to make sure it works with both cloud version and self-hosted version.