### PR TITLE
Fix proguard/R8 minification breaking JSON parsing

### DIFF
--- a/FlagsmithClient/consumer-rules.pro
+++ b/FlagsmithClient/consumer-rules.pro
@@ -1,0 +1,4 @@
+# prevent proguard / R8 from obfuscating entity fields
+-keep class com.flagsmith.entities.** {
+    <fields>;
+}


### PR DESCRIPTION
Consuming the SDK with `isMinifyEnabled = true` obfuscated all entity fields.
And as most of the entity fields do not have the `@SerializedName` annotation either, GSON will no longer be able to deserialise the JSON responses.

The proguard rule to solve this is aligned to this GSON example:
https://github.com/google/gson/blob/3adead6ab4f240ed53322eff34210ed4a69dd490/examples/android-proguard-example/proguard.cfg#L14