### PR TITLE
Remove cache eviction on init and add a method to allow consumers to clear the cache

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -150,6 +150,10 @@ class Flagsmith constructor(
         retrofit.getIdentityFlagsAndTraits(identity).enqueueWithResult(defaults = null, result = result)
             .also { lastUsedIdentity = identity }
 
+    fun clearCache() {
+        cache?.evictAll()
+    }
+
     private fun getFeatureFlag(
         featureId: String,
         identity: String?,

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -96,9 +96,6 @@ interface FlagsmithRetrofitService {
                 .cache(cache)
                 .build()
 
-            // Make sure that we start with a clean cache
-            client.cache?.evictAll()
-
             val retrofit = Retrofit.Builder()
                 .baseUrl(baseUrl)
                 .addConverterFactory(GsonConverterFactory.create())


### PR DESCRIPTION
## Description

I've removed the cache eviction that was highlighted in #36, added a method to clear the cache and also checked it with some unit tests.

You could argue that this changes the behaviour slightly, though in the majority of cases this would be minimal and would improve performance for those not using the real-time functionality.

## Type of Change

Add more control to the SDK for the consumer

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore