### PR TITLE
Fix initialisation error on the Flagsmith SDK when enabling analytics - fixes #39

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -45,10 +45,7 @@ class Flagsmith constructor(
     private lateinit var retrofit: FlagsmithRetrofitService
     private var cache: Cache? = null
     private var lastUsedIdentity: String? = null
-    private val analytics: FlagsmithAnalytics? =
-        if (!enableAnalytics) null
-        else if (context != null) FlagsmithAnalytics(context, retrofit, analyticsFlushPeriod)
-        else throw IllegalArgumentException("Flagsmith requires a context to use the analytics feature")
+    private var analytics: FlagsmithAnalytics? = null //TODO: Make this a lateinit var and instead initialise in init block
 
     private val eventService: FlagsmithEventService? =
         if (!enableRealtimeUpdates) null
@@ -93,6 +90,13 @@ class Flagsmith constructor(
             writeTimeoutSeconds = writeTimeoutSeconds, timeTracker = this, klass = FlagsmithRetrofitService::class.java)
         retrofit = pair.first
         cache = pair.second
+
+        if (enableAnalytics) {
+            if (context == null || context.applicationContext == null) {
+                throw IllegalArgumentException("Flagsmith requires a context to use the analytics feature")
+            }
+            analytics = FlagsmithAnalytics(context, retrofit, analyticsFlushPeriod)
+        }
     }
 
     companion object {

--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -45,7 +45,7 @@ class Flagsmith constructor(
     private lateinit var retrofit: FlagsmithRetrofitService
     private var cache: Cache? = null
     private var lastUsedIdentity: String? = null
-    private var analytics: FlagsmithAnalytics? = null //TODO: Make this a lateinit var and instead initialise in init block
+    private var analytics: FlagsmithAnalytics? = null
 
     private val eventService: FlagsmithEventService? =
         if (!enableRealtimeUpdates) null

--- a/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
@@ -77,7 +77,7 @@ class FeatureFlagCachingTests {
         flagsmithWithCache = Flagsmith(
             environmentKey = "",
             baseUrl = "http://localhost:${mockServer.localPort}",
-            enableAnalytics = false,
+            enableAnalytics = true, // Mix up the analytics flag to test initialisation
             context = mockApplicationContext,
             defaultFlags = defaultFlags,
             cacheConfig = FlagsmithCacheConfig(enableCache = true)
@@ -112,6 +112,7 @@ class FeatureFlagCachingTests {
         `when`(mockContextResources.getBoolean(anyInt())).thenReturn(false)
         `when`(mockContextResources.getDimension(anyInt())).thenReturn(100f)
         `when`(mockContextResources.getIntArray(anyInt())).thenReturn(intArrayOf(1, 2, 3))
+        `when`(mockApplicationContext.applicationContext).thenReturn(mockApplicationContext)
     }
 
     @After


### PR DESCRIPTION
## Description

An issue had been reported in https://github.com/Flagsmith/flagsmith-kotlin-android-client/issues/39. This turned out to be an error on initialisation where an `lateinit` property hadn't yet been initialised. 

I updated the unit tests to reproduce the issue, fixed the issue, and also ensured that an incorrect initialisation flags were returning the same helpful assertions as before.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore