### PR TITLE
feat(typing): allow non-string trait values

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -45,10 +45,7 @@ class Flagsmith constructor(
     private lateinit var retrofit: FlagsmithRetrofitService
     private var cache: Cache? = null
     private var lastUsedIdentity: String? = null
-    private val analytics: FlagsmithAnalytics? =
-        if (!enableAnalytics) null
-        else if (context != null) FlagsmithAnalytics(context, retrofit, analyticsFlushPeriod)
-        else throw IllegalArgumentException("Flagsmith requires a context to use the analytics feature")
+    private var analytics: FlagsmithAnalytics? = null
 
     private val eventService: FlagsmithEventService? =
         if (!enableRealtimeUpdates) null
@@ -93,6 +90,13 @@ class Flagsmith constructor(
             writeTimeoutSeconds = writeTimeoutSeconds, timeTracker = this, klass = FlagsmithRetrofitService::class.java)
         retrofit = pair.first
         cache = pair.second
+
+        if (enableAnalytics) {
+            if (context == null || context.applicationContext == null) {
+                throw IllegalArgumentException("Flagsmith requires a context to use the analytics feature")
+            }
+            analytics = FlagsmithAnalytics(context, retrofit, analyticsFlushPeriod)
+        }
     }
 
     companion object {

--- a/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
@@ -6,11 +6,11 @@ import com.google.gson.annotations.SerializedName
 data class Trait(
     val identifier: String? = null,
     @SerializedName(value = "trait_key") val key: String,
-    @SerializedName(value = "trait_value") val value: String
+    @SerializedName(value = "trait_value") val value: dynamic
 )
 
 data class TraitWithIdentity(
     @SerializedName(value = "trait_key") val key: String,
-    @SerializedName(value = "trait_value") val value: String,
+    @SerializedName(value = "trait_value") val value: dynamic,
     val identity: Identity
 )

--- a/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
@@ -6,11 +6,19 @@ import com.google.gson.annotations.SerializedName
 data class Trait(
     val identifier: String? = null,
     @SerializedName(value = "trait_key") val key: String,
-    @SerializedName(value = "trait_value") val value: dynamic
-)
+    @SerializedName(value = "trait_value") val value: String
+) {
+    constructor(key: String, value: String) : this(null, key, value)
+}
 
 data class TraitWithIdentity(
     @SerializedName(value = "trait_key") val key: String,
-    @SerializedName(value = "trait_value") val value: dynamic,
-    val identity: Identity
-)
+    @SerializedName(value = "trait_value") val value: Any,
+    val identity: Identity,
+) {
+    // Add a constructor that takes a string and sets the value to it
+    constructor(key: String, value: String, identity: Identity) : this(key, value as Any, identity)
+
+    // Add a constructor that takes an int and sets the value to it
+    constructor(key: String, value: Int, identity: Identity) : this(key, value as Any, identity)
+}

--- a/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
@@ -77,7 +77,7 @@ class FeatureFlagCachingTests {
         flagsmithWithCache = Flagsmith(
             environmentKey = "",
             baseUrl = "http://localhost:${mockServer.localPort}",
-            enableAnalytics = false,
+            enableAnalytics = true, // Mix up the analytics flag to test initialisation
             context = mockApplicationContext,
             defaultFlags = defaultFlags,
             cacheConfig = FlagsmithCacheConfig(enableCache = true)
@@ -112,6 +112,7 @@ class FeatureFlagCachingTests {
         `when`(mockContextResources.getBoolean(anyInt())).thenReturn(false)
         `when`(mockContextResources.getDimension(anyInt())).thenReturn(100f)
         `when`(mockContextResources.getIntArray(anyInt())).thenReturn(intArrayOf(1, 2, 3))
+        `when`(mockApplicationContext.applicationContext).thenReturn(mockApplicationContext)
     }
 
     @After


### PR DESCRIPTION
Changes the type of trait_value to `dynamic` so that users can set integer, float and boolean traits. 

I think this will constitute a major release since we have methods such as `getTrait` which will now return the `Trait` classes with the new attribute type. 