### PR TITLE
Added try-catch to clearCache method

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -14,6 +14,7 @@ import com.flagsmith.internal.FlagsmithRetrofitService
 import com.flagsmith.internal.enqueueWithResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import okhttp3.Cache
+import java.io.IOException
 
 /**
  * Flagsmith
@@ -160,7 +161,11 @@ class Flagsmith constructor(
             .also { lastUsedIdentity = identity }
 
     fun clearCache() {
-        cache?.evictAll()
+        try {
+            cache?.evictAll()
+        } catch (e: IOException) {
+            Log.e("Flagsmith", "Error clearing cache", e)
+        }
     }
 
     private fun getFeatureFlag(


### PR DESCRIPTION
Method `evictAll` can throw `IOException`, but in SDK method `clearCache` this exception is not handled, as a result in this case app is crashed.
Added simple handling of `IOException`.