### PR TITLE
ci: auto publish in maven central

### DIFF
--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/prepare-gradle
 
       - name: Publish to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew FlagsmithClient:publishAndReleaseToMavenCentral
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - "ci/auto-publish"
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "ci/auto-publish"
 
 jobs:
   publish:


### PR DESCRIPTION
This PR just ensures that the publish step is done automatically when releasing to maven central. 

Note that I tested this by adding the branch to the GH workflow and watching the job succeed (and publish to maven central). Note that, because there was no tag associated, however, it published version 0.1.0 as can be seen here: 

https://github.com/Flagsmith/flagsmith-kotlin-android-client/actions/runs/11456462086/job/31874638853
https://central.sonatype.com/artifact/io.flagsmith/flagsmith-kotlin-android-client/versions