### PR TITLE
ci: migrate from `io.flagsmith` namespace to `com.flagsmith`

### DIFF
--- a/FlagsmithClient/build.gradle.kts
+++ b/FlagsmithClient/build.gradle.kts
@@ -196,7 +196,7 @@ mavenPublishing {
 
     signAllPublications()
 
-    coordinates("io.flagsmith", "flagsmith-kotlin-android-client", versionNumber)
+    coordinates("com.flagsmith", "flagsmith-kotlin-android-client", versionNumber)
 
     pom {
         name.set("Flagsmith Kotlin Android Client")


### PR DESCRIPTION
Migrate deployments from `io.flagsmith` to `com.flagsmith`