### PR TITLE
fix: Exclude `transient` properties when false

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/entities/IdentityAndTraits.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/entities/IdentityAndTraits.kt
@@ -1,9 +1,27 @@
 package com.flagsmith.entities
 
+import com.google.gson.*
 import com.google.gson.annotations.SerializedName
+import java.lang.reflect.Type
 
 data class IdentityAndTraits(
     @SerializedName(value = "identifier") val identifier: String,
     @SerializedName(value = "traits") val traits: List<Trait>,
     @SerializedName(value = "transient") val transient: Boolean? = null
 )
+
+class IdentityAndTraitsSerializer : JsonSerializer<IdentityAndTraits> {
+    override fun serialize(src: IdentityAndTraits, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        // Create a JsonObject with all fields except transient
+        val jsonObject = JsonObject()
+        jsonObject.addProperty("identifier", src.identifier)
+        jsonObject.add("traits", context.serialize(src.traits))
+        
+        // Only add transient if it's true
+        if (src.transient == true) {
+            jsonObject.addProperty("transient", true)
+        }
+        
+        return jsonObject
+    }
+}

--- a/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/entities/Trait.kt
@@ -1,8 +1,8 @@
 package com.flagsmith.entities
 
-
+import com.google.gson.*
 import com.google.gson.annotations.SerializedName
-
+import java.lang.reflect.Type
 
 data class Trait (
     val identifier: String? = null,
@@ -44,6 +44,19 @@ data class Trait (
 
     val booleanValue: Boolean?
         get() = traitValue as? Boolean
+}
+
+class TraitSerializer : JsonSerializer<Trait> {
+    override fun serialize(src: Trait, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val jsonObject = JsonObject()
+        src.identifier?.let { jsonObject.addProperty("identifier", it) }
+        jsonObject.addProperty("trait_key", src.key)
+        jsonObject.addProperty("trait_value", src.traitValue.toString())
+        if (src.transient) {
+            jsonObject.addProperty("transient", true)
+        }
+        return jsonObject
+    }
 }
 
 data class TraitWithIdentity (

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -5,7 +5,10 @@ import android.util.Log
 import com.flagsmith.FlagsmithCacheConfig
 import com.flagsmith.entities.Flag
 import com.flagsmith.entities.IdentityAndTraits
+import com.flagsmith.entities.IdentityAndTraitsSerializer
 import com.flagsmith.entities.IdentityFlagsAndTraits
+import com.flagsmith.entities.Trait
+import com.flagsmith.entities.TraitSerializer
 import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -15,6 +18,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
+import com.google.gson.GsonBuilder
 
 interface FlagsmithRetrofitService {
 
@@ -97,9 +101,14 @@ interface FlagsmithRetrofitService {
                 .cache(cache)
                 .build()
 
+            val gson = GsonBuilder()
+                .registerTypeAdapter(IdentityAndTraits::class.java, IdentityAndTraitsSerializer())
+                .registerTypeAdapter(Trait::class.java, TraitSerializer())
+                .create()
+
             val retrofit = Retrofit.Builder()
                 .baseUrl(baseUrl)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create(gson))
                 .client(client)
                 .build()
 

--- a/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagTests.kt
@@ -182,11 +182,9 @@ class FeatureFlagTests {
                                 },
                                 {
                                   "trait_key": "persisted-trait",
-                                  "trait_value": "value",
-                                  "transient": false
+                                  "trait_value": "value"
                                 }
-                              ],
-                              "transient": false
+                              ]
                             }
                         """.trimIndent()
                     )

--- a/FlagsmithClient/src/test/java/com/flagsmith/entities/SerializerTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/entities/SerializerTests.kt
@@ -1,0 +1,82 @@
+package com.flagsmith.entities
+
+import com.google.gson.GsonBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SerializerTests {
+    private val gson = GsonBuilder()
+        .registerTypeAdapter(IdentityAndTraits::class.java, IdentityAndTraitsSerializer())
+        .registerTypeAdapter(Trait::class.java, TraitSerializer())
+        .create()
+
+    @Test
+    fun `IdentityAndTraitsSerializer omits transient field when false`() {
+        val identity = IdentityAndTraits(
+            identifier = "test-user",
+            traits = listOf(Trait("key", "value")),
+            transient = false
+        )
+
+        val json = gson.toJson(identity)
+        assertEquals(
+            """{"identifier":"test-user","traits":[{"trait_key":"key","trait_value":"value"}]}""",
+            json
+        )
+    }
+
+    @Test
+    fun `IdentityAndTraitsSerializer includes transient field when true`() {
+        val identity = IdentityAndTraits(
+            identifier = "test-user",
+            traits = listOf(Trait("key", "value")),
+            transient = true
+        )
+
+        val json = gson.toJson(identity)
+        assertEquals(
+            """{"identifier":"test-user","traits":[{"trait_key":"key","trait_value":"value"}],"transient":true}""",
+            json
+        )
+    }
+
+    @Test
+    fun `TraitSerializer omits transient field when false`() {
+        val trait = Trait("key", "value", false)
+        val json = gson.toJson(trait)
+        assertEquals(
+            """{"trait_key":"key","trait_value":"value"}""",
+            json
+        )
+    }
+
+    @Test
+    fun `TraitSerializer includes transient field when true`() {
+        val trait = Trait("key", "value", true)
+        val json = gson.toJson(trait)
+        assertEquals(
+            """{"trait_key":"key","trait_value":"value","transient":true}""",
+            json
+        )
+    }
+
+    @Test
+    fun `TraitSerializer handles optional identifier`() {
+        val traitWithId = Trait(
+            identifier = "test-id",
+            key = "key",
+            traitValue = "value",
+            transient = false
+        )
+        val traitWithoutId = Trait("key", "value", false)
+
+        assertEquals(
+            """{"identifier":"test-id","trait_key":"key","trait_value":"value"}""",
+            gson.toJson(traitWithId)
+        )
+        assertEquals(
+            """{"trait_key":"key","trait_value":"value"}""",
+            gson.toJson(traitWithoutId)
+        )
+    }
+} 


### PR DESCRIPTION
Currently, the `transient` field for identities and traits are set even when they are `false`. The API only checks for the presence of this field, and not whether it's true or false.

Even if we do fix this at the API level, it might still be desirable to exclude this from SDKs for compatibility with older Flagsmith versions.

See https://github.com/Flagsmith/flagsmith/issues/5260 for more details.