### PR TITLE
Exclude transient query parameter from identities request when false

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -182,7 +182,7 @@ class Flagsmith constructor(
     }
 
     fun getIdentity(identity: String, transient: Boolean = false, result: (Result<IdentityFlagsAndTraits>) -> Unit) =
-        retrofit.getIdentityFlagsAndTraits(identity, transient).enqueueWithResult(defaults = null, result = result)
+        retrofit.getIdentityFlagsAndTraits(identity, if (transient) true else null).enqueueWithResult(defaults = null, result = result)
             .also { lastUsedIdentity = identity }
 
     fun clearCache() {

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -88,29 +88,11 @@ interface FlagsmithRetrofitService {
                 }
             }
 
-            fun queryInterceptor(): Interceptor {
-                return Interceptor { chain ->
-                    val request = chain.request()
-                    if (request.method == "GET" && request.url.pathSegments.contains("identities") && request.url.queryParameter("transient") == "false") {
-                        val url = request.url.newBuilder()
-                            .removeAllQueryParameters("transient")
-                            .build()
-                        val newRequest = request.newBuilder()
-                            .url(url)
-                            .build()
-                        chain.proceed(newRequest)
-                    } else {
-                        chain.proceed(request)
-                    }
-                }
-            }
-
             val cache = if (context != null && cacheConfig.enableCache) Cache(context.cacheDir, cacheConfig.cacheSize) else null
 
             val client = OkHttpClient.Builder()
                 .addInterceptor(envKeyInterceptor(environmentKey))
                 .addInterceptor(updatedAtInterceptor(timeTracker))
-                .addInterceptor(queryInterceptor())
                 .addInterceptor(jsonContentTypeInterceptor())
                 .let { if (cacheConfig.enableCache) it.addNetworkInterceptor(cacheControlInterceptor()) else it }
                 .callTimeout(requestTimeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -23,7 +23,7 @@ import com.google.gson.GsonBuilder
 interface FlagsmithRetrofitService {
 
     @GET("identities/")
-    fun getIdentityFlagsAndTraits(@Query("identifier") identity: String, @Query("transient") transient: Boolean = false) : Call<IdentityFlagsAndTraits>
+    fun getIdentityFlagsAndTraits(@Query("identifier") identity: String, @Query("transient") transient: Boolean? = null) : Call<IdentityFlagsAndTraits>
 
     @GET("flags/")
     fun getFlags() : Call<List<Flag>>

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -88,11 +88,29 @@ interface FlagsmithRetrofitService {
                 }
             }
 
+            fun queryInterceptor(): Interceptor {
+                return Interceptor { chain ->
+                    val request = chain.request()
+                    if (request.method == "GET" && request.url.pathSegments.contains("identities") && request.url.queryParameter("transient") == "false") {
+                        val url = request.url.newBuilder()
+                            .removeAllQueryParameters("transient")
+                            .build()
+                        val newRequest = request.newBuilder()
+                            .url(url)
+                            .build()
+                        chain.proceed(newRequest)
+                    } else {
+                        chain.proceed(request)
+                    }
+                }
+            }
+
             val cache = if (context != null && cacheConfig.enableCache) Cache(context.cacheDir, cacheConfig.cacheSize) else null
 
             val client = OkHttpClient.Builder()
                 .addInterceptor(envKeyInterceptor(environmentKey))
                 .addInterceptor(updatedAtInterceptor(timeTracker))
+                .addInterceptor(queryInterceptor())
                 .addInterceptor(jsonContentTypeInterceptor())
                 .let { if (cacheConfig.enableCache) it.addNetworkInterceptor(cacheControlInterceptor()) else it }
                 .callTimeout(requestTimeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)

--- a/FlagsmithClient/src/test/java/com/flagsmith/IdentityTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/IdentityTests.kt
@@ -74,6 +74,23 @@ class IdentityTests {
     }
 
     @Test
+    fun testGetIdentityWithoutTransientParameter() {
+        mockServer.mockResponseFor(MockEndpoint.GET_IDENTITIES)
+        runBlocking {
+            flagsmith.getIdentitySync("person")
+            val requests = mockServer.retrieveRecordedRequests(
+                request()
+                    .withPath("/identities/")
+                    .withMethod("GET")
+            )
+            assertEquals(1, requests.size)
+            val request = requests[0]
+            val transientParam = request.queryStringParameterList.find { it.name.toString() == "transient" }
+            assertNull("transient parameter should not be present", transientParam)
+        }
+    }
+
+    @Test
     fun testGetTransientIdentity() {
         mockServer.mockResponseFor(MockEndpoint.GET_TRANSIENT_IDENTITIES)
         runBlocking {

--- a/FlagsmithClient/src/test/java/com/flagsmith/IdentityTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/IdentityTests.kt
@@ -58,6 +58,21 @@ class IdentityTests {
         }
     }
 
+    @Test(expected = AssertionError::class)
+    fun testGetIdentityWithExpectedParameterMissing() {
+        mockServer.mockResponseFor(MockEndpoint.GET_IDENTITIES)
+        runBlocking {
+            flagsmith.getIdentitySync("person")
+
+            mockServer.verify(
+                request()
+                    .withPath("/identities/")
+                    .withMethod("GET")
+                    .withQueryStringParameter("transient")
+            )
+        }
+    }
+
     @Test
     fun testGetTransientIdentity() {
         mockServer.mockResponseFor(MockEndpoint.GET_TRANSIENT_IDENTITIES)


### PR DESCRIPTION
Currently, get identities request contains `transient` query parameter only when set to `true`.

Previously, this bug would result in an unexpected flag state for the user identity.

- Implemented according to [iOS library implementation](https://github.com/Flagsmith/flagsmith-ios-client/blob/99e4ca6775386edcea5a1b7c8449d71f2accdba7/FlagsmithClient/Classes/Internal/Router.swift#L51).
- Covered with test.