### PR TITLE
feat: Make most Feature fields optional

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/entities/Flag.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/entities/Flag.kt
@@ -9,11 +9,11 @@ data class Flag(
 )
 
 data class Feature(
-    val id: Long,
     val name: String,
-    @SerializedName(value = "created_date") val createdDate: String,
-    val description: String,
-    @SerializedName(value = "initial_value") val initialValue: String,
-    @SerializedName(value = "default_enabled") val defaultEnabled: Boolean,
-    val type: String
+    val id: Long = 0L,
+    @SerializedName(value = "created_date") val createdDate: String = "",
+    val description: String = "",
+    @SerializedName(value = "initial_value") val initialValue: String = "",
+    @SerializedName(value = "default_enabled") val defaultEnabled: Boolean = false,
+    val type: String = ""
 )

--- a/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/FeatureFlagCachingTests.kt
@@ -51,26 +51,14 @@ class FeatureFlagCachingTests {
         setupMocks()
         val defaultFlags = listOf(
             Flag(
-                feature = Feature(
-                    id = 345345L,
-                    name = "Flag 1",
-                    createdDate = "2023‐07‐07T09:07:16Z",
-                    description = "Flag 1 description",
-                    type = "CONFIG",
-                    defaultEnabled = true,
-                    initialValue = "true"
-                ), enabled = true, featureStateValue = "Vanilla Ice"
+                feature = Feature(name = "Flag 1"),
+                enabled = true,
+                featureStateValue = "Vanilla Ice"
             ),
             Flag(
-                feature = Feature(
-                    id = 34345L,
-                    name = "Flag 2",
-                    createdDate = "2023‐07‐07T09:07:16Z",
-                    description = "Flag 2 description",
-                    type = "CONFIG",
-                    defaultEnabled = true,
-                    initialValue = "true"
-                ), enabled = true, featureStateValue = "value2"
+                feature = Feature(name = "Flag 2"),
+                enabled = true,
+                featureStateValue = "value2"
             ),
         )
 


### PR DESCRIPTION
Currently, defining default flags requires passing a list of `Flag`s. Each flag contains a `Feature`, which has many unnecessary fields when it comes to defining default flags:

```
id
createdDate
description
type
defaultEnabled
initialValue
```

This PR makes all of these fields optional, so that default flags can be defined like this:

```kotlin
val defaultFlags = listOf(
    Flag(
        feature = Feature(
            name = "Flag 1",
        ),
        enabled = true,
        featureStateValue = "value1"
    ),
    Flag(
        feature = Feature(
            name = "Flag 2",
        ),
        enabled = true,
        featureStateValue = "value2"
    ),
)
```

instead of:

```kotlin
val defaultFlags = listOf(
    Flag(
        feature = Feature(
            id = 345345L,
            name = "Flag 1",
            createdDate = "2023‐07‐07T09:07:16Z",
            description = "Flag 1 description",
            type = "CONFIG",
            defaultEnabled = true,
            initialValue = "true"
        ), enabled = true, featureStateValue = "value1"
    ),
    Flag(
        feature = Feature(
            id = 34345L,
            name = "Flag 2",
            createdDate = "2023‐07‐07T09:07:16Z",
            description = "Flag 2 description",
            type = "CONFIG",
            defaultEnabled = true,
            initialValue = "true"
        ), enabled = true, featureStateValue = "value2"
    ),
)
```