### PR TITLE
chore: Bump okhttp, kotlin and java target version

### DIFF
--- a/FlagsmithClient/build.gradle.kts
+++ b/FlagsmithClient/build.gradle.kts
@@ -58,11 +58,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     testOptions {
@@ -79,8 +76,8 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
 
     // Server Sent Events
-    implementation("com.squareup.okhttp3:okhttp-sse:4.11.0")
-    testImplementation("com.squareup.okhttp3:okhttp-sse:4.11.0")
+    implementation("com.squareup.okhttp3:okhttp-sse:5.3.2")
+    testImplementation("com.squareup.okhttp3:okhttp-sse:5.3.2")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application").version("8.5.1").apply(false)
     id("com.android.library").version("8.5.1").apply(false)
-    kotlin("android").version("1.8.0").apply(false)
+    kotlin("android").version("2.3.20").apply(false)
     id("org.jetbrains.kotlinx.kover").version("0.6.1").apply(false)
 
     id("com.vanniktech.maven.publish").version("0.29.0")


### PR DESCRIPTION
Bump `okhttp-sse` version.
Bumping `okhttp-sse` version pulls the need to bump `kotlin` and `Java` target/compatibility version.

The project is lagging in a lot of major versions which are creating dependency conflicts inside projects with newer dependency versions. 