### PR TITLE
feat: Send a standard User-Agent: sdk-name/version header

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithEventService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithEventService.kt
@@ -19,6 +19,7 @@ internal class FlagsmithEventService constructor(
 ) {
     private val sseClient = OkHttpClient.Builder()
         .addInterceptor(FlagsmithRetrofitService.envKeyInterceptor(environmentKey))
+        .addInterceptor(FlagsmithRetrofitService.userAgentInterceptor())
         .connectTimeout(6, TimeUnit.SECONDS)
         .readTimeout(10, TimeUnit.MINUTES)
         .writeTimeout(10, TimeUnit.MINUTES)

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt
@@ -39,6 +39,20 @@ interface FlagsmithRetrofitService {
         private const val UPDATED_AT_HEADER = "x-flagsmith-document-updated-at"
         private const val ACCEPT_HEADER_VALUE = "application/json"
         private const val CONTENT_TYPE_HEADER_VALUE = "application/json; charset=utf-8"
+        private const val USER_AGENT_HEADER = "User-Agent"
+
+        // x-release-please-start-version
+        private const val SDK_VERSION = "1.8.0"
+        // x-release-please-end
+
+        fun userAgentInterceptor(): Interceptor {
+            return Interceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header(USER_AGENT_HEADER, "flagsmith-kotlin-android-sdk/$SDK_VERSION")
+                    .build()
+                chain.proceed(request)
+            }
+        }
 
         fun <T : FlagsmithRetrofitService> create(
             baseUrl: String,
@@ -92,6 +106,7 @@ interface FlagsmithRetrofitService {
 
             val client = OkHttpClient.Builder()
                 .addInterceptor(envKeyInterceptor(environmentKey))
+                .addInterceptor(userAgentInterceptor())
                 .addInterceptor(updatedAtInterceptor(timeTracker))
                 .addInterceptor(jsonContentTypeInterceptor())
                 .let { if (cacheConfig.enableCache) it.addNetworkInterceptor(cacheControlInterceptor()) else it }

--- a/FlagsmithClient/src/test/java/com/flagsmith/UserAgentTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/UserAgentTests.kt
@@ -1,0 +1,55 @@
+package com.flagsmith
+
+import com.flagsmith.mockResponses.MockEndpoint
+import com.flagsmith.mockResponses.mockResponseFor
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.model.HttpRequest.request
+
+class UserAgentTests {
+
+    private lateinit var mockServer: ClientAndServer
+    private lateinit var flagsmith: Flagsmith
+
+    @Before
+    fun setup() {
+        mockServer = ClientAndServer.startClientAndServer()
+        flagsmith = Flagsmith(
+            environmentKey = "",
+            baseUrl = "http://localhost:${mockServer.localPort}",
+            enableAnalytics = false,
+            cacheConfig = FlagsmithCacheConfig(enableCache = false)
+        )
+    }
+
+    @After
+    fun tearDown() {
+        mockServer.stop()
+    }
+
+    @Test
+    fun testUserAgentHeaderIsSent() {
+        mockServer.mockResponseFor(MockEndpoint.GET_FLAGS)
+        runBlocking {
+            val result = flagsmith.getFeatureFlagsSync()
+            assertTrue(result.isSuccess)
+        }
+
+        val requests = mockServer.retrieveRecordedRequests(
+            request()
+                .withPath("/flags/")
+                .withMethod("GET")
+        )
+        assertEquals(1, requests.size)
+
+        val userAgent = requests[0].getFirstHeader("User-Agent")
+        // x-release-please-start-version
+        assertEquals("flagsmith-kotlin-android-sdk/1.8.0", userAgent)
+        // x-release-please-end
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,11 @@
             "bump-patch-for-minor-pre-major": false,
             "draft": false,
             "prerelease": false,
-            "include-component-in-tag": false
+            "include-component-in-tag": false,
+            "extra-files": [
+                "FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithRetrofitService.kt",
+                "FlagsmithClient/src/test/java/com/flagsmith/UserAgentTests.kt"
+            ]
         }
     },
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
The Flagsmith API cannot currently distinguish which SDK or version is making requests from this client. This is part of a cross-SDK effort to standardize User-Agent headers — iOS (https://github.com/Flagsmith/flagsmith-ios-client/pull/95) and Flutter (https://github.com/Flagsmith/flagsmith-flutter-client/pull/85) already ship theirs. The version strategy follows the same release-please approach decided during review of #77 (https://github.com/Flagsmith/flagsmith-kotlin-android-client/pull/77#discussion_r2528452408).

## Changes

- [x] Every outbound HTTP request (REST API and real-time) identifies the SDK and its version
- [x] SDK version stays current automatically after each release

Supersedes #77
Closes #73

Review effort: 1/5