### PR TITLE
fix: Fixed bug when request returns empty list on network call error

### DIFF
--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -38,7 +38,7 @@ class Flagsmith constructor(
     private val enableRealtimeUpdates: Boolean = false,
     private val analyticsFlushPeriod: Int = DEFAULT_ANALYTICS_FLUSH_PERIOD_SECONDS,
     private val cacheConfig: FlagsmithCacheConfig = FlagsmithCacheConfig(),
-    private val defaultFlags: List<Flag>? = null,
+    private val defaultFlags: List<Flag>? = emptyList(),
     private val requestTimeoutSeconds: Long = 4L,
     private val readTimeoutSeconds: Long = 6L,
     private val writeTimeoutSeconds: Long = 6L,

--- a/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/Flagsmith.kt
@@ -38,7 +38,7 @@ class Flagsmith constructor(
     private val enableRealtimeUpdates: Boolean = false,
     private val analyticsFlushPeriod: Int = DEFAULT_ANALYTICS_FLUSH_PERIOD_SECONDS,
     private val cacheConfig: FlagsmithCacheConfig = FlagsmithCacheConfig(),
-    private val defaultFlags: List<Flag> = emptyList(),
+    private val defaultFlags: List<Flag>? = null,
     private val requestTimeoutSeconds: Long = 4L,
     private val readTimeoutSeconds: Long = 6L,
     private val writeTimeoutSeconds: Long = 6L,


### PR DESCRIPTION
If there is no internet connection and a network request fails, this call returns the empty list specified in the default constructor instead of throwing an error.
This breaks app logic.

Also this change aligns behavior with swift version.